### PR TITLE
Fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vorta for Borg Backup: Documentation
 
-Has the content of [vorta.borgbase.com](https://docs.borgbase.com). Feel free to open a pull request if you notice any mistake or would like to add something.
+Has the content of [vorta.borgbase.com](https://vorta.borgbase.com). Feel free to open a pull request if you notice any mistake or would like to add something.
 
 ## Setup
 - Install dependencies: `gem install --user-install jekyll bundler`


### PR DESCRIPTION
Change link from docs.borgbase.com to vorta.borgbase.com to match text