### PR TITLE
Add Ubuntu PPA

### DIFF
--- a/install/linux.md
+++ b/install/linux.md
@@ -41,9 +41,9 @@ Maintained by [@bjo81](https://github.com/bjo81).
 
 ### Solus Linux
 Use the official [package](https://dev.getsol.us/source/vorta/). Command for install:
-
-`$ sudo eopkg it vorta`
-
+```
+$ sudo eopkg it vorta
+```
 Maintained by [@kyrios123](https://github.com/kyrios123).
 
 

--- a/install/linux.md
+++ b/install/linux.md
@@ -48,7 +48,7 @@ Maintained by [@kyrios123](https://github.com/kyrios123).
 
 
 ### Ubuntu Linux
-Use the unoffical [PPA](https://launchpad.net/~samuel-w1/+archive/ubuntu/vorta/). Supports 20.04 and greater. Command for install:
+Use the official [PPA](https://launchpad.net/~samuel-w1/+archive/ubuntu/vorta/). Supports 20.04 and greater. Command for install:
 ```
 $ sudo add-apt-repository ppa:samuel-w1/vorta
 $ sudo apt-get update

--- a/install/linux.md
+++ b/install/linux.md
@@ -47,6 +47,16 @@ Use the official [package](https://dev.getsol.us/source/vorta/). Command for ins
 Maintained by [@kyrios123](https://github.com/kyrios123).
 
 
+### Ubuntu Linux
+Use the unoffical [PPA](https://launchpad.net/~samuel-w1/+archive/ubuntu/vorta/). Supports 20.04 and greater. Command for install:
+```
+$ sudo add-apt-repository ppa:samuel-w1/vorta
+$ sudo apt-get update
+$ sudo apt-get install vorta
+```
+Maintained by [@samuel-w](https://github.com/samuel-w).
+
+
 **Looking to maintain a package?** [Open](https://github.com/borgbase/vorta/issues/new) an issue or pull request and it will be added here.
 
 


### PR DESCRIPTION
Finally fixed translations by bundling them with install.

Releasing on older Ubuntu versions is blocked by:
1. PyQt5 old versions don't provide metadata, easy to patch out https://github.com/pypa/setuptools/issues/1445.
2. Paramiko old versions do not support Ed25519 keys, harder to patch out and would be confusing when some keys don't appear, Ed25519 appears in 2.2.0 https://github.com/paramiko/paramiko/commit/b03ebb2d64ec87da589d6fcfa4f1c00ead40c1a7. I _could_ include package paramiko as well, but then I would have to package its dependencies, and that's more problems to deal with.

and possibly more.