### PR TITLE
Reorder installation guidelines in order of preference

### DIFF
--- a/install/linux.md
+++ b/install/linux.md
@@ -7,6 +7,17 @@ parent: Download
 ---
 # Install on Linux
 
+## Flatpak
+Can be installed on any Linux distribution. Find Vorta on [Flathub](https://flathub.org/apps/details/com.borgbase.Vorta). To install:
+```
+$ flatpak install flathub com.borgbase.Vorta
+```
+
+Settings can be transferred by copying `~/.local/share/Vorta/settings.db` to `~/.var/app/com.borgbase.Vorta/data/Vorta/`.
+
+Maintained by [@Hofer-Julian](https://github.com/Hofer-Julian).
+
+
 ## Distribution Packages
 
 ### Arch Linux
@@ -36,21 +47,10 @@ $ sudo apt-get install vorta
 Maintained by [@samuel-w](https://github.com/samuel-w).
 
 
-## Flatpak
-Can be installed on any Linux distribution. Find Vorta on [Flathub](https://flathub.org/apps/details/com.borgbase.Vorta). To install:
-```
-$ flatpak install flathub com.borgbase.Vorta
-```
-
-Settings can be transferred by copying `~/.local/share/Vorta/settings.db` to `~/.var/app/com.borgbase.Vorta/data/Vorta/`.
-
-Maintained by [@Hofer-Julian](https://github.com/Hofer-Julian).
-
-
 ## Install from Source
-The most generic way is to install it as Python package using [PIP](https://pip.readthedocs.io/en/stable/installing/). First [install](https://borgbackup.readthedocs.io/en/stable/installation.html) Borg using the package of your distribution or via PyPI. The latter needs some additional [source packages](https://borgbackup.readthedocs.io/en/stable/installation.html#dependencies). Then install Vorta from PyPI. Your local Python version must be >= 3.6.
+If there top two options do not work, Vorta can be installed as a Python package using [pipx](https://pypi.org/project/pipx/). First [install](https://borgbackup.readthedocs.io/en/stable/installation.html) Borg using the package of your distribution or via PyPI. The latter needs some additional [source packages](https://borgbackup.readthedocs.io/en/stable/installation.html#dependencies). Then install Vorta from PyPI. Your local Python version must be >= 3.6.
 ```
-$ pip3 install vorta
+$ pipx install vorta
 ```
 
 ### Add Entry to Application Launcher

--- a/install/linux.md
+++ b/install/linux.md
@@ -19,7 +19,7 @@ Maintained by [@Hofer-Julian](https://github.com/Hofer-Julian).
 
 
 ## Distribution Packages
-
+[![Overview](https://repology.org/badge/vertical-allrepos/vorta.svg)](https://repology.org/project/vorta/versions)
 ### Arch Linux
 Use the [AUR package](https://aur.archlinux.org/packages/vorta/).
 ```
@@ -37,8 +37,15 @@ $ sudo eopkg it vorta
 Maintained by [@kyrios123](https://github.com/kyrios123).
 
 
-### Ubuntu Linux
-Use the official [PPA](https://launchpad.net/~samuel-w1/+archive/ubuntu/vorta/). Supports 20.04 and greater. Command for install:
+### Debian 11/Ubuntu 20.10
+Use the official [package](https://packages.debian.org/unstable/utils/vorta). Command for install:
+```
+$ sudo apt-get install vorta
+```
+
+
+### Ubuntu PPA
+Use the [PPA](https://launchpad.net/~samuel-w1/+archive/ubuntu/vorta/). It is more up to date. Supports 20.04 and greater. Command for install:
 ```
 $ sudo add-apt-repository ppa:samuel-w1/vorta
 $ sudo apt-get update

--- a/install/linux.md
+++ b/install/linux.md
@@ -48,7 +48,7 @@ Maintained by [@samuel-w](https://github.com/samuel-w).
 
 
 ## Install from Source
-If there top two options do not work, Vorta can be installed as a Python package using [pipx](https://pypi.org/project/pipx/). First [install](https://borgbackup.readthedocs.io/en/stable/installation.html) Borg using the package of your distribution or via PyPI. The latter needs some additional [source packages](https://borgbackup.readthedocs.io/en/stable/installation.html#dependencies). Then install Vorta from PyPI. Your local Python version must be >= 3.6.
+If there top two options do not work, Vorta can be installed as a Python package using [PIP](https://pip.readthedocs.io/en/stable/installing/). First [install](https://borgbackup.readthedocs.io/en/stable/installation.html) Borg using the package of your distribution or via PyPI. The latter needs some additional [source packages](https://borgbackup.readthedocs.io/en/stable/installation.html#dependencies). Then install Vorta from PyPI. Your local Python version must be >= 3.6.
 ```
 $ pipx install vorta
 ```

--- a/install/linux.md
+++ b/install/linux.md
@@ -7,27 +7,6 @@ parent: Download
 ---
 # Install on Linux
 
-## Flatpak
-Can be installed on any Linux distribution. Find Vorta on [Flathub](https://flathub.org/apps/details/com.borgbase.Vorta). To install:
-```
-$ flatpak install flathub com.borgbase.Vorta
-```
-
-Settings can be transferred by copying `~/.local/share/Vorta/settings.db` to `~/.var/app/com.borgbase.Vorta/data/Vorta/`.
-
-Maintained by [@Hofer-Julian](https://github.com/Hofer-Julian).
-
-
-## Install from Source
-The most generic way is to install it as Python package using [PIP](https://pip.readthedocs.io/en/stable/installing/). First [install](https://borgbackup.readthedocs.io/en/stable/installation.html) Borg using the package of your distribution or via PyPI. The latter needs some additional [source packages](https://borgbackup.readthedocs.io/en/stable/installation.html#dependencies). Then install Vorta from PyPI. Your local Python version must be >= 3.6.
-```
-$ pip3 install vorta
-```
-
-### Add Entry to Application Launcher
-You can add a `.desktop` entry to get a link to Vorta in your application launcher, usually `~/.local/share/applications/vorta.desktop`. Use the template available [here](https://github.com/borgbase/vorta/blob/master/src/vorta/assets/metadata/com.borgbase.Vorta.desktop) and adjust the `Exec` and [`Icon`](https://github.com/borgbase/vorta/blob/master/src/vorta/assets/icons/scalable/com.borgbase.Vorta.svg) paths if necessary. 
-
-
 ## Distribution Packages
 
 ### Arch Linux
@@ -56,6 +35,26 @@ $ sudo apt-get install vorta
 ```
 Maintained by [@samuel-w](https://github.com/samuel-w).
 
+
+## Flatpak
+Can be installed on any Linux distribution. Find Vorta on [Flathub](https://flathub.org/apps/details/com.borgbase.Vorta). To install:
+```
+$ flatpak install flathub com.borgbase.Vorta
+```
+
+Settings can be transferred by copying `~/.local/share/Vorta/settings.db` to `~/.var/app/com.borgbase.Vorta/data/Vorta/`.
+
+Maintained by [@Hofer-Julian](https://github.com/Hofer-Julian).
+
+
+## Install from Source
+The most generic way is to install it as Python package using [PIP](https://pip.readthedocs.io/en/stable/installing/). First [install](https://borgbackup.readthedocs.io/en/stable/installation.html) Borg using the package of your distribution or via PyPI. The latter needs some additional [source packages](https://borgbackup.readthedocs.io/en/stable/installation.html#dependencies). Then install Vorta from PyPI. Your local Python version must be >= 3.6.
+```
+$ pip3 install vorta
+```
+
+### Add Entry to Application Launcher
+You can add a `.desktop` entry to get a link to Vorta in your application launcher, usually `~/.local/share/applications/vorta.desktop`. Use the template available [here](https://github.com/borgbase/vorta/blob/master/src/vorta/assets/metadata/com.borgbase.Vorta.desktop) and adjust the `Exec` and [`Icon`](https://github.com/borgbase/vorta/blob/master/src/vorta/assets/icons/scalable/com.borgbase.Vorta.svg) paths if necessary. 
 
 **Looking to maintain a package?** [Open](https://github.com/borgbase/vorta/issues/new) an issue or pull request and it will be added here.
 

--- a/install/linux.md
+++ b/install/linux.md
@@ -50,7 +50,7 @@ Maintained by [@samuel-w](https://github.com/samuel-w).
 ## Install from Source
 If the earlier options do not work, Vorta can be installed as a Python package using [PIP](https://pip.readthedocs.io/en/stable/installing/). First [install](https://borgbackup.readthedocs.io/en/stable/installation.html) Borg using the package of your distribution or via PyPI. The latter needs some additional [source packages](https://borgbackup.readthedocs.io/en/stable/installation.html#dependencies). Then install Vorta from PyPI. Your local Python version must be >= 3.6.
 ```
-$ pipx install vorta
+$ pip install vorta
 ```
 
 ### Add Entry to Application Launcher

--- a/install/linux.md
+++ b/install/linux.md
@@ -48,7 +48,7 @@ Maintained by [@samuel-w](https://github.com/samuel-w).
 
 
 ## Install from Source
-If there top two options do not work, Vorta can be installed as a Python package using [PIP](https://pip.readthedocs.io/en/stable/installing/). First [install](https://borgbackup.readthedocs.io/en/stable/installation.html) Borg using the package of your distribution or via PyPI. The latter needs some additional [source packages](https://borgbackup.readthedocs.io/en/stable/installation.html#dependencies). Then install Vorta from PyPI. Your local Python version must be >= 3.6.
+If the earlier options do not work, Vorta can be installed as a Python package using [PIP](https://pip.readthedocs.io/en/stable/installing/). First [install](https://borgbackup.readthedocs.io/en/stable/installation.html) Borg using the package of your distribution or via PyPI. The latter needs some additional [source packages](https://borgbackup.readthedocs.io/en/stable/installation.html#dependencies). Then install Vorta from PyPI. Your local Python version must be >= 3.6.
 ```
 $ pipx install vorta
 ```


### PR DESCRIPTION
The pip guidelines should indicate in some way that it is not recommended.

Since official repos take time to update, should we put flatpak first?