### PR TITLE
Separate packaging and translations better.

### DIFF
--- a/contributing/index.md
+++ b/contributing/index.md
@@ -15,8 +15,6 @@ If your questions are Borg-specific it might be advisable to join the #borgbacku
 
 ## Local Development Setup
 
-### macOS (or Linux if Flatpak is not an option) with pip
-
 Clone the latest version of this repo:
 ```
 $ git clone https://github.com/borgbase/vorta/
@@ -37,7 +35,7 @@ Then run as Python script. Any changes from your source folder should be reflect
 $ vorta
 ```
 
-#### Working on the GUI
+## Working on the GUI
 
 Qt Creator is used to edit views. Install from [their site](https://www.qt.io/download) or using Homebrew and then open the .ui files in `vorta/assets/UI` with Qt Creator:
 ```
@@ -45,46 +43,10 @@ $ brew cask install qt-creator
 $ brew install qt
 ```
 
-### Linux with flatpak
-
-The recommended way to build Vorta on Linux is via Flatpak.
-This can be done by following these [instructions](https://wiki.gnome.org/Newcomers/BuildProject).
-They first guide you through the installation of the IDE GNOME Builder.
-GNOME Builder is then used to clone, build and run Vorta.
-
-
-#### Working on the GUI
-
-Qt Creator is used to edit views. Install using your package manager (typically called `qt-creator` or `qtcreator`) or from [their site](https://www.qt.io/download) and then open the .ui files in `vorta/assets/UI` with Qt Creator.
-
 ## Icons
 
 For UI icons, we use Fontawesome. You can browse available icons [here](https://fontawesome.com/icons) and download them as SVG [here](https://github.com/encharm/Font-Awesome-SVG-PNG). New icons are first added to src/vorta/assets/icons, and can be gotten with the `get_colored_icon` function
 
-## Notes for Developers
-
-- Original strings in `.ui` and `.py` must be American English (en_US) and ASCII.
-- In English, not translated:
-  - log messages (log file as well as log output on console or elsewhere)
-  - other console output, print().
-  - docs
-  - py source code, comments, docstrings
-
-- Translated:
-  - GUI texts / messages
-
-- In Qt (sub)classes, use self.tr("English string"), scope will
-  be the instance class name.
-- Elsewhere use vorta.i18n.translate("scopename", "English string")
-- To only mark for string extraction, but not immediately translate,
-  use vorta.i18n.trans_late function.
-  Later, to translate, use vorta.i18n.translate (giving same scope).
-
-## Building Binaries
-To build a macOS app package:
-- add `Sparkle.framework` from [here](https://github.com/sparkle-project/Sparkle) and `borg` from [here](https://github.com/borgbackup/borg/releases) in `bin/macosx64`
-- then uncomment or change the Apple signing profile to be used in `Makefile`
-- finally run to `$ make Vorta.app` to build the app into the `dist` folder.
 
 ## Testing
 

--- a/contributing/packaging.md
+++ b/contributing/packaging.md
@@ -7,7 +7,26 @@ parent: Contributing
 ---
 # Packaging Vorta
 
+## macOS Application Bundle
+
+To build a macOS app package, run the Github Actions workflow "Build macOS release". You can choose a repo branch and Borg version to use. The workflow will do the following:
+
+1. Build an application bundle using PyInstaller
+2. Integrate Sparkle (for updates) and Borg (as fallback if Borg isn't installed)
+3. Provide the resulting app bundle as zipped artifact for downloading
+
+After downloading the app bundle, unzip it and open it via right-click > open to get around Gatekeeper.
+
+Once you are happy with the app, sign and package it as DMG locally using `make dist/Vorta.dmg`
+
+
 ## Linux with Flatpak
+
+The recommended way to build Vorta on Linux is via Flatpak. This can be done by following these [instructions](https://wiki.gnome.org/Newcomers/BuildProject).
+
+They first guide you through the installation of the IDE GNOME Builder. GNOME Builder is then used to clone, build and run Vorta.
+
+### Installing Flatpak
 
 Follow the setup guide on [flatpak.org](http://flatpak.org/setup/) to make sure you have ``flatpak`` and ``flathub`` installed.
 

--- a/contributing/packaging.md
+++ b/contributing/packaging.md
@@ -17,16 +17,14 @@ To build a macOS app package, run the Github Actions workflow "Build macOS relea
 
 After downloading the app bundle, unzip it and open it via right-click > open to get around Gatekeeper.
 
-Once you are happy with the app, sign and package it as DMG locally using `make dist/Vorta.dmg`
+Once you are happy with the app, sign and package it as DMG locally using `make dist/Vorta.dmg`. For this step, XCode and `create-dmg` should be installed and those environment variables defined:
+
+- CERTIFICATE_NAME="Developer ID Application: Joe Doe (XXXXXX)"
+- APPLE_ID_USER="name@example.com"
+- APPLE_ID_PASSWORD="@keychain:Notarization"
 
 
 ## Linux with Flatpak
-
-The recommended way to build Vorta on Linux is via Flatpak. This can be done by following these [instructions](https://wiki.gnome.org/Newcomers/BuildProject).
-
-They first guide you through the installation of the IDE GNOME Builder. GNOME Builder is then used to clone, build and run Vorta.
-
-### Installing Flatpak
 
 Follow the setup guide on [flatpak.org](http://flatpak.org/setup/) to make sure you have ``flatpak`` and ``flathub`` installed.
 

--- a/contributing/translations.md
+++ b/contributing/translations.md
@@ -43,13 +43,11 @@ Translations are managed on [Transifex](https://www.Transifex.com/borgbase/vorta
 - Compile: `make translations-to-qm`
 - Test with specific translation: `LANG=de vorta`
 - Scale strings to test UI: `LANG=de TRANS_SCALE=200 vorta --foreground`
-  
-We use Qt's translation framework. Some guidelines for translations:
-
-
 
 
 ### Style Guide/Glossary
+
+We use Qt's translation framework. Some guidelines for translations:
 
 - Original strings in `.ui` and `.py` must be American English (en_US) and ASCII.
 - Headings, buttons and dropdowns are titleized: "Apply Changes"
@@ -72,9 +70,8 @@ Translated:
 Add new strings for translation:
 - In Qt (sub)classes, use self.tr("English string"), scope will
   be the instance class name.
-- Elsewhere use vorta.i18n.translate("scopename", "English string")
-- To only mark for string extraction, but not immediately translate, use 
-  vorta.i18n.trans_late function. Later, to translate, use vorta.i18n.translate (giving same scope).
+- Elsewhere use `vorta.i18n.translate("scopename", "English string")`
+- To only mark a string, but not translate: `vorta.i18n.trans_late` (Translated string will be used later. E.g. when displaying settings.)
 
 
 ### Required Software

--- a/contributing/translations.md
+++ b/contributing/translations.md
@@ -9,6 +9,7 @@ parent: Contributing
 
 Translations are managed on [Transifex](https://www.Transifex.com/borgbase/vorta/). If you are interested in adding a new language, first let us know in the [translation thread](https://github.com/borgbase/vorta/issues/159). We will then set you up on Transifex. No coding skill are required for translations.
 
+
 ### Policy for Translations
 
 - No google translate or other automated translation.
@@ -43,8 +44,14 @@ Translations are managed on [Transifex](https://www.Transifex.com/borgbase/vorta
 - Test with specific translation: `LANG=de vorta`
 - Scale strings to test UI: `LANG=de TRANS_SCALE=200 vorta --foreground`
   
+We use Qt's translation framework. Some guidelines for translations:
+
+
+
+
 ### Style Guide/Glossary
 
+- Original strings in `.ui` and `.py` must be American English (en_US) and ASCII.
 - Headings, buttons and dropdowns are titleized: "Apply Changes"
 - Field labels (same or next line) end with a colon and are titleized. "Allowed Networks:"
 - No full stop `.` at the end of short labels, but when it's a full sentence.
@@ -52,6 +59,23 @@ Translations are managed on [Transifex](https://www.Transifex.com/borgbase/vorta
 - **Repo/repository** = local or remote folder where Borg stores files.
 - **Archive** (not snapshot) = result of `borg create` execution, an identifier to find a
   collection of files in a repo, as they existed at a past point in time.
+
+Not translated, always in English:
+- log messages (log file as well as log output on console or elsewhere)
+- other console output, print().
+- docs
+- py source code, comments, docstrings
+
+Translated:
+- GUI texts / messages
+
+Add new strings for translation:
+- In Qt (sub)classes, use self.tr("English string"), scope will
+  be the instance class name.
+- Elsewhere use vorta.i18n.translate("scopename", "English string")
+- To only mark for string extraction, but not immediately translate, use 
+  vorta.i18n.trans_late function. Later, to translate, use vorta.i18n.translate (giving same scope).
+
 
 ### Required Software
 


### PR DESCRIPTION
I made some changes to the contributor docs to document the new macOS packaging workflow.

Also noticed that some Flatpak instructions are probably duplicate and moved some translation stuff from the main page to the translation page.

@samuel-w , can you check if both Flatpak sections in *Packaging* are needed? Here: https://github.com/borgbase/vorta.borgbase.com/blob/b49fd8c06b122b639901d914517c81103a7334d8/contributing/packaging.md

How are the two Flatpak sections related?