### PR TITLE
Mention Flatpak sandboxed folders, sort from least to most specific.

### DIFF
--- a/install/linux.md
+++ b/install/linux.md
@@ -8,21 +8,9 @@ parent: Install
 
 # Install on Linux
 
-## Flatpak
-
-Can be installed on any Linux distribution. Find Vorta on [Flathub](https://flathub.org/apps/details/com.borgbase.Vorta). To install:
-
-```
-$ flatpak install flathub com.borgbase.Vorta
-```
-
-Settings can be transferred by copying `~/.local/share/Vorta/settings.db` to `~/.var/app/com.borgbase.Vorta/data/Vorta/`.
-
-Maintained by [@Hofer-Julian](https://github.com/Hofer-Julian).
-
 ## Install from Source
 
-The most generic way is to install it as Python package using [PIP](https://pip.readthedocs.io/en/stable/installing/). First [install](https://borgbackup.readthedocs.io/en/stable/installation.html) Borg using the package of your distribution or via PyPI. The latter needs some additional [source packages](https://borgbackup.readthedocs.io/en/stable/installation.html#dependencies). Then install Vorta from PyPI. Your local Python version must be >= 3.6.
+The most generic way is to install it as Python package using [PIP](https://pip.readthedocs.io/en/stable/installing/). First [install](https://borgbackup.readthedocs.io/en/stable/installation.html) Borg using the package of your distribution or via PyPI. The latter needs some additional [source packages](https://borgbackup.readthedocs.io/en/stable/installation.html#dependencies). Then install Vorta from PyPI. Your local Python version must be >= 3.6. If you keep Python packages in your home folder, you can add the `--user` option.
 
 ```
 $ pip3 install vorta
@@ -31,6 +19,22 @@ $ pip3 install vorta
 ### Add Entry to Application Launcher
 
 You can add a `.desktop` entry to get a link to Vorta in your application launcher, usually `~/.local/share/applications/vorta.desktop`. Use the template available [here](https://github.com/borgbase/vorta/blob/master/src/vorta/assets/metadata/com.borgbase.Vorta.desktop) and adjust the `Exec` and [`Icon`](https://github.com/borgbase/vorta/blob/master/src/vorta/assets/icons/scalable/com.borgbase.Vorta.svg) paths if necessary.
+
+
+## Flatpak
+
+Can be installed on any Linux distribution. Find Vorta on [Flathub](https://flathub.org/apps/details/com.borgbase.Vorta). To install:
+
+```
+$ flatpak install flathub com.borgbase.Vorta
+```
+
+Flatpak apps run in a sandboxed environment and can't access certain folders, like `/root`, `/etc` and `/var`. See [here](https://docs.flatpak.org/de/latest/sandbox-permissions.html#filesystem-access) for the full list. If you need access to those directories, consider a different installation option.
+
+Settings can be transferred by copying `~/.local/share/Vorta/settings.db` to `~/.var/app/com.borgbase.Vorta/data/Vorta/`.
+
+Maintained by [@Hofer-Julian](https://github.com/Hofer-Julian).
+
 
 ## Distribution Packages
 

--- a/install/linux.md
+++ b/install/linux.md
@@ -8,19 +8,6 @@ parent: Install
 
 # Install on Linux
 
-## Install from Source
-
-The most generic way is to install it as Python package using [PIP](https://pip.readthedocs.io/en/stable/installing/). First [install](https://borgbackup.readthedocs.io/en/stable/installation.html) Borg using the package of your distribution or via PyPI. The latter needs some additional [source packages](https://borgbackup.readthedocs.io/en/stable/installation.html#dependencies). Then install Vorta from PyPI. Your local Python version must be >= 3.6. If you keep Python packages in your home folder, you can add the `--user` option.
-
-```
-$ pip3 install vorta
-```
-
-### Add Entry to Application Launcher
-
-You can add a `.desktop` entry to get a link to Vorta in your application launcher, usually `~/.local/share/applications/vorta.desktop`. Use the template available [here](https://github.com/borgbase/vorta/blob/master/src/vorta/assets/metadata/com.borgbase.Vorta.desktop) and adjust the `Exec` and [`Icon`](https://github.com/borgbase/vorta/blob/master/src/vorta/assets/icons/scalable/com.borgbase.Vorta.svg) paths if necessary.
-
-
 ## Flatpak
 
 Can be installed on any Linux distribution. Find Vorta on [Flathub](https://flathub.org/apps/details/com.borgbase.Vorta). To install:
@@ -34,6 +21,19 @@ Flatpak apps run in a sandboxed environment and can't access certain folders, li
 Settings can be transferred by copying `~/.local/share/Vorta/settings.db` to `~/.var/app/com.borgbase.Vorta/data/Vorta/`.
 
 Maintained by [@Hofer-Julian](https://github.com/Hofer-Julian).
+
+
+## Install from Source
+
+The most generic way is to install it as Python package using [PIP](https://pip.readthedocs.io/en/stable/installing/). First [install](https://borgbackup.readthedocs.io/en/stable/installation.html) Borg using the package of your distribution or via PyPI. The latter needs some additional [source packages](https://borgbackup.readthedocs.io/en/stable/installation.html#dependencies). Then install Vorta from PyPI. Your local Python version must be >= 3.6. If you keep Python packages in your home folder, you can add the `--user` option.
+
+```
+$ pip3 install vorta
+```
+
+### Add Entry to Application Launcher
+
+You can add a `.desktop` entry to get a link to Vorta in your application launcher, usually `~/.local/share/applications/vorta.desktop`. Use the template available [here](https://github.com/borgbase/vorta/blob/master/src/vorta/assets/metadata/com.borgbase.Vorta.desktop) and adjust the `Exec` and [`Icon`](https://github.com/borgbase/vorta/blob/master/src/vorta/assets/icons/scalable/com.borgbase.Vorta.svg) paths if necessary.
 
 
 ## Distribution Packages


### PR DESCRIPTION
- Mention restricted folders in Flatpak sandbox
- Order install options from most general (Pip) to most specific (distribution package).

Fixes https://github.com/borgbase/vorta/issues/962