### PR TITLE
Update brew qt-creator install command

### DIFF
--- a/contributing/index.md
+++ b/contributing/index.md
@@ -138,7 +138,7 @@ pre-commit run
 Qt Creator or Qt Designer is used to edit views. There are many ways to install one of these two applications. For MacOS you can use homebrew or install from [their site](https://www.qt.io/download). Then you can open the .ui files in `vorta/assets/UI` with Qt Creator. To learn about PyQt we recommend the following [tutorial](https://www.pythonguis.com/pyqt5-tutorial/).
 
 ```
-brew cask install qt-creator
+brew install --cask qt-creator
 brew install qt
 ```
 


### PR DESCRIPTION
I was just running through the contributor guide to get the QT development tools installed on macOS and found this out of date command.

The `brew cask install` syntax no longer works. The correct syntax is now `brew install —cask`. 

This PR updates it so it works with modern Homebrew installations.