### PR TITLE
Arch package is official (not AUR)

### DIFF
--- a/install/linux.md
+++ b/install/linux.md
@@ -38,13 +38,11 @@ You can add a `.desktop` entry to get a link to Vorta in your application launch
 
 ### Arch Linux
 
-Use the [AUR package](https://archlinux.org/packages/extra/any/vorta/).
+Install from the [official repositories](https://archlinux.org/packages/extra/any/vorta/).
 
 ```
-$ yay -S vorta
+$ pacman -S vorta
 ```
-
-Maintained by [@bjo81](https://github.com/bjo81).
 
 ### Debian and derivatives
 


### PR DESCRIPTION
Vorta is available in the official repositories (in extra).  The link was corrected in c615f3d62fc117028f393fceeb15d65f1b9ccbf8, but the description and instructions still referenced the AUR.